### PR TITLE
Bump rust_arenaclient from 0.1.20 to 0.1.21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ typing==3.7.4.3
 aiodns==3.0.0
 Brotli==1.0.9
 loguru==0.6.0
-rust_arenaclient==0.1.20
+rust_arenaclient==0.1.21
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "rust_arenaclient==0.1.20",
+        "rust_arenaclient==0.1.21",
         "requests==2.25.1",
         "aiohttp==3.7.4",
         "termcolor==1.1.0",


### PR DESCRIPTION
Because rust_arenaclient has been updated to support Python3.10 https://github.com/aiarena/rust-arenaclient/actions/runs/2436920303
and https://github.com/aiarena/aiarena-docker requires Python3.10 support, I created this PR.

rust_arenaclient for Python3.10 is only available starting at version 0.1.21